### PR TITLE
Prefer composition over inheritance for the storage class

### DIFF
--- a/Hangfire.MAMQSqlExtension/MAMQSqlServerStorage.cs
+++ b/Hangfire.MAMQSqlExtension/MAMQSqlServerStorage.cs
@@ -1,22 +1,49 @@
 ﻿
 namespace Hangfire.MAMQSqlExtension
 {
+    using Hangfire.Logging;
+    using Hangfire.Server;
+    using Hangfire.States;
     using Hangfire.Storage;
     using Hangfire.SqlServer;
     using System.Collections.Generic;
 
-    public class MAMQSqlServerStorage : SqlServerStorage
+    public class MAMQSqlServerStorage : JobStorage
     {
-        private IEnumerable<string>? _queues;
+        private readonly IEnumerable<string>? _queues;
+        private readonly SqlServerStorage _inner;
 
-        public MAMQSqlServerStorage(string nameOrConnectionString, SqlServerStorageOptions options, IEnumerable<string>? queues) : base(nameOrConnectionString, options)
+        public MAMQSqlServerStorage(string nameOrConnectionString, SqlServerStorageOptions options, IEnumerable<string>? queues)
         {
+            _inner = new SqlServerStorage(nameOrConnectionString, options);
             _queues = queues;
         }
 
+        public override bool LinearizableReads => _inner.LinearizableReads;
+
         public override IStorageConnection GetConnection()
         {
-            return new MAMQSqlServerConnection(this, _queues);
+            return new MAMQSqlServerConnection(_inner, _queues);
+        }
+
+        public override IMonitoringApi GetMonitoringApi()
+        {
+            return _inner.GetMonitoringApi();
+        }
+
+        public override IEnumerable<IServerComponent> GetComponents()
+        {
+            return _inner.GetComponents();
+        }
+
+        public override IEnumerable<IStateHandler> GetStateHandlers()
+        {
+            return _inner.GetStateHandlers();
+        }
+
+        public override void WriteOptionsToLog(ILog logger)
+        {
+            _inner.WriteOptionsToLog(logger);
         }
     }
 }


### PR DESCRIPTION
I've just got this issue on GitHub – https://github.com/HangfireIO/Hangfire/issues/2201 – that states that application throws an exception after upgrading to the recently released [Hangfire 1.8.0](https://github.com/HangfireIO/Hangfire/releases/tag/v1.8.0) when using this extension. Hangfire now includes more virtual methods in the `JobStorage`, and has the `HasFeature` method that returns `true` or `false` values if some additional methods are implemented.

Unfortunately when the `SqlServerStorage` class is inherited by some other class, but doesn't implement the new members, that `HasFeature` mechanism doesn't work properly, because it returns `true` if some method is considered to be implemented, but inherited class actually doesn't contain the implementation.

So I've re-implemented the `MSMQSqlServerStorage` class using composition instead of inheritance. It now inherits abstract `JobStorage` class and creates a new instance of the `SqlServerStorage` one in the constructor. The new changes are compatible with old releases and don't require `Hangfire.Core` dependency to be bumped to the latest version. These changes make it possible to use this extension with Hangfire 1.8.0, however without the new features.