### PR TITLE
More constructors for SqlServerStorage to support Managed Identity

### DIFF
--- a/Hangfire.MAMQSqlExtension/MAMQIGlobalConfigurationExtension.cs
+++ b/Hangfire.MAMQSqlExtension/MAMQIGlobalConfigurationExtension.cs
@@ -20,5 +20,33 @@
             var storage = new MAMQSqlServerStorage(nameOrConnectionString, options, queues);
             return configuration.UseStorage(storage);
         }
+
+        public static IGlobalConfiguration<MAMQSqlServerStorage> UseMAMQSqlServerStorage(
+            this IGlobalConfiguration configuration,
+            System.Func<System.Data.Common.DbConnection> connectionFactory,
+            SqlServerStorageOptions options,
+           IEnumerable<string> queues)
+        {
+            if (configuration == null) throw new ArgumentNullException(nameof(configuration));
+            if (connectionFactory == null) throw new ArgumentNullException(nameof(connectionFactory));
+            if (options == null) throw new ArgumentNullException(nameof(options));
+
+            var storage = new MAMQSqlServerStorage(connectionFactory, options, queues);
+            return configuration.UseStorage(storage);
+        }
+
+        public static IGlobalConfiguration<MAMQSqlServerStorage> UseMAMQSqlServerStorage(
+            this IGlobalConfiguration configuration,
+            System.Data.Common.DbConnection existingConnection,
+            SqlServerStorageOptions options,
+           IEnumerable<string> queues)
+        {
+            if (configuration == null) throw new ArgumentNullException(nameof(configuration));
+            if (existingConnection == null) throw new ArgumentNullException(nameof(existingConnection));
+            if (options == null) throw new ArgumentNullException(nameof(options));
+
+            var storage = new MAMQSqlServerStorage(existingConnection, options, queues);
+            return configuration.UseStorage(storage);
+        }
     }
 }

--- a/Hangfire.MAMQSqlExtension/MAMQSqlServerStorage.cs
+++ b/Hangfire.MAMQSqlExtension/MAMQSqlServerStorage.cs
@@ -19,6 +19,18 @@ namespace Hangfire.MAMQSqlExtension
             _queues = queues;
         }
 
+        public MAMQSqlServerStorage(System.Func<System.Data.Common.DbConnection> connectionFactory, SqlServerStorageOptions options, IEnumerable<string>? queues)
+        {
+            _inner = new SqlServerStorage(connectionFactory, options);
+            _queues = queues;
+        }
+
+        public MAMQSqlServerStorage(System.Data.Common.DbConnection existingConnection, SqlServerStorageOptions options, IEnumerable<string>? queues)
+        {
+            _inner = new SqlServerStorage(existingConnection, options);
+            _queues = queues;
+        }
+    
         public override bool LinearizableReads => _inner.LinearizableReads;
 
         public override IStorageConnection GetConnection()


### PR DESCRIPTION
Support more constructors for SqlServerStorage, so that Azure Managed Identities can be used (see workaround from https://github.com/HangfireIO/Hangfire/issues/1827).